### PR TITLE
[APC-5893] epc660: respect reset timings

### DIFF
--- a/drivers/media/i2c/soc_camera/epc660.c
+++ b/drivers/media/i2c/soc_camera/epc660.c
@@ -398,6 +398,7 @@ static long epc660_ioctl(struct v4l2_subdev *sd, unsigned int cmd, void* arg)
 			break;
 		case EPC_660_IOCTL_CMD_RESET:
 			epc660_reset(sd, 0);
+			epc660_reset(sd, 1);
 			break;
 		default:
 			break;
@@ -414,12 +415,9 @@ static int epc660_reset(struct v4l2_subdev *sd, u32 val) {
 	    dev_err(&client->dev, "EPC660: cannot set nrst_gpio to %d\n", val);
 	} else {
 		dev_info(&client->dev, "EPC660 reset %d\n", val);
-		if(val == 0) {
-			udelay(1);
-		} else {
-			usleep_range(7000, 10000);
-		}
-	}
+		//wait for tStartup
+		usleep_range(7000, 10000);
+	}		
 	return ret;
 }
 


### PR DESCRIPTION
Calling reset only from user space is currently not functional. Luckily, after a reset the video capture device is opened again, which [triggers](https://github.com/iris-GmbH/linux-gen6/blob/develop/drivers/media/platform/iris-gen6/epc660_capture_sc57x.c#L986) the [epc660_load_fw](https://github.com/iris-GmbH/linux-gen6/blob/1d25b85f83c8b63b5ad92faf25b1dcb21adb1736/drivers/media/i2c/soc_camera/epc660.c#L435) function, which leaves the reset correctly again.

This MR also fixes this dependency.

- Pipeline: https://gitlab.devops.defra01.iris-sensing.net/public-projects/yocto/meta-iris-base/-/pipelines/10777
- See https://gitlab.devops.defra01.iris-sensing.net/public-projects/yocto/meta-iris-base/-/merge_requests/205 for more details.