### PR TITLE
Revert "[APC-5893] epc660: respect reset timings"

### DIFF
--- a/drivers/media/i2c/soc_camera/epc660.c
+++ b/drivers/media/i2c/soc_camera/epc660.c
@@ -398,7 +398,6 @@ static long epc660_ioctl(struct v4l2_subdev *sd, unsigned int cmd, void* arg)
 			break;
 		case EPC_660_IOCTL_CMD_RESET:
 			epc660_reset(sd, 0);
-			epc660_reset(sd, 1);
 			break;
 		default:
 			break;
@@ -415,9 +414,12 @@ static int epc660_reset(struct v4l2_subdev *sd, u32 val) {
 	    dev_err(&client->dev, "EPC660: cannot set nrst_gpio to %d\n", val);
 	} else {
 		dev_info(&client->dev, "EPC660 reset %d\n", val);
-		//wait for tStartup
-		usleep_range(7000, 10000);
-	}		
+		if(val == 0) {
+			udelay(1);
+		} else {
+			usleep_range(7000, 10000);
+		}
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Since some devices have communication problems with the epc660:
```
bus: 'i2c': add device 0-0022
bus: 'i2c': driver_probe_device: matched device 0-0022 with driver epc660
bus: 'i2c': really_probe: probing driver epc660 with device 0-0022
epc660 0-0022: no of_node; not parsing pinctrl DT
epc660 0-0022: no default pinctrl state
epc660 0-0022: EPC660 reset 0
epc660 0-0022: EPC660 reset 1
epc660 0-0022: EPC660: cannot read reg ic version
epc660: probe of 0-0022 failed with error -11
device: '0-0022': device_unregister
```
