### PR TITLE
[APC-7188] Set VB2_MAX_FRAME/VIDEO_MAX_FRAME up to 128 (from former 32)

### DIFF
--- a/include/media/videobuf2-core.h
+++ b/include/media/videobuf2-core.h
@@ -17,7 +17,7 @@
 #include <linux/poll.h>
 #include <linux/dma-buf.h>
 
-#define VB2_MAX_FRAME	(32)
+#define VB2_MAX_FRAME (128)
 #define VB2_MAX_PLANES	(8)
 
 /**

--- a/include/uapi/linux/videodev2.h
+++ b/include/uapi/linux/videodev2.h
@@ -70,7 +70,7 @@
  * Common stuff for both V4L1 and V4L2
  * Moved from videodev.h
  */
-#define VIDEO_MAX_FRAME               32
+#define VIDEO_MAX_FRAME              128
 #define VIDEO_MAX_PLANES               8
 
 /*


### PR DESCRIPTION
Merge Request for further processing with the kernel changes (for Release 1 and Release 2) in meta-iris-base.
The changes were tested so far with commit 7a3f03d9f567d551fdf7f524c1574ff59b9c6a7e
in HAL::Imager repository, branch feature/jaha/APC-7187.