### PR TITLE
[APC-8162] Remove the code setting the ROI registers in EPC660 Imager…

### DIFF
--- a/drivers/media/i2c/soc_camera/epc660.c
+++ b/drivers/media/i2c/soc_camera/epc660.c
@@ -258,12 +258,6 @@ static int epc660_set_fmt(struct v4l2_subdev *sd,
 	struct v4l2_mbus_framefmt *mf = &format->format;
 	struct i2c_client *client = v4l2_get_subdevdata(sd);
 	struct epc660 *epc660 = to_epc660(client);
-	const int centerX = (324+4)/2;
-	const int centerY = (246+6)/2;
-	const int bY = centerY-1;
-	int lX;
-	int rX;
-	int uY;
 	int walign = 4;
 	int halign = 1;
 
@@ -277,18 +271,6 @@ static int epc660_set_fmt(struct v4l2_subdev *sd,
 	epc660->fmt = epc660_find_datafmt(mf->code, epc660->fmts,
 				   epc660->num_fmts);
 	mf->colorspace	= epc660->fmt->colorspace;
-
-	// set the ROI on the EPC
-	lX = (centerX - mf->width / 2) & ~1; // the ROI has to start at an even offset
-	rX = lX + mf->width - 1;
-	uY = (centerY - mf->height / 2) & ~1; // the ROI has to start at an even offset
-
-	lX = ((lX >> 8) & 0xff) | ((lX << 8) & 0xff00);
-	rX = ((rX >> 8) & 0xff) | ((rX << 8) & 0xff00);
-	reg_write(client, EPC660_REG_ROI_TL_X_HI, lX);
-	reg_write(client, EPC660_REG_ROI_BR_X_HI, rX);
-	reg_write_byte(client, EPC660_REG_ROI_TL_Y, uY);
-	reg_write_byte(client, EPC660_REG_ROI_BR_Y, bY);
 
 	epc660->rect.width  = mf->width;
 	epc660->rect.height = mf->height;


### PR DESCRIPTION
… chip

Description from the jira ticket https://iris-sensing.jira.com/browse/APC-6404:

After merging  https://iris-sensing.jira.com/browse/APC-6408 / https://iris-sensing.jira.com/browse/APC-8102, it is shown that the image on the actual develop firmware for Release 1 sensor is corrupt.
Analysis shows, that the ROI registers are set in driver without knowledge of the changes in the register map. 
Taht’s why the values aren’t reset with the call of function “setROI” in Epc660Imager.cpp → setFormat.

Solution: Removing the lines configuring the ROI registers from the function  epc660_set_fmt (Lines after comment “set the ROI on the EPC“)

Pipeline successfully run:
https://gitlab.devops.defra01.iris-sensing.net/public-projects/yocto/meta-iris-base/-/pipelines/66112

Tested on Release 1, image is correct as expected.
