### PR TITLE
[APC-8364] sc57x.dtsi: Set the right phy-addr

### DIFF
--- a/arch/arm/boot/dts/sc57x.dtsi
+++ b/arch/arm/boot/dts/sc57x.dtsi
@@ -270,6 +270,7 @@
 			snps,force_sf_dma_mode;
 			snps,perfect-filter-entries = <32>;
 			phy-mode = "rmii";
+			snps,phy-addr = <1>;
 			clock-names = "stmmaceth";
 			pinctrl-names = "default";
 			pinctrl-0 = <&eth0_default>;


### PR DESCRIPTION
This change fix's:
- The carrier check support (`cat /sys/class/net/eth0/carrier`) -> it was always 1 also if no cable is connected, and
- Resetting the eth0 interface. -> `ifconfig eth0 down` then `ifconfig eth0 up`