### PR TITLE
[APC-8633] spi2: Disable dma-mode

### DIFF
--- a/arch/arm/boot/dts/sc573-gen6.dts
+++ b/arch/arm/boot/dts/sc573-gen6.dts
@@ -171,7 +171,7 @@
 				spi-cpha;
 				spi-tx-bus-width = <4>;
 				spi-rx-bus-width = <4>;
-				dma-mode;
+				/* dma-mode; */
 
 				partition@0 {
 					label = "uboot (spi)";


### PR DESCRIPTION
It's a workaround because the SPI DMA implementation causes sporadic problems.